### PR TITLE
When waiting for pod deployment select on knative label

### DIFF
--- a/.tanzu/wait.sh
+++ b/.tanzu/wait.sh
@@ -2,4 +2,4 @@
 
 workload=$1
 while [[ -z $(kubectl get pod -o jsonpath='{.items[?(@.metadata.annotations.developer\.apps\.tanzu\.vmware\.com/image-source-digest=="'$(kubectl get imagerepository ${workload}-source -o=jsonpath='{.status.url}')'")].metadata.name}') ]]; do echo "waiting..." && sleep 10; done 
-kubectl wait pod --for=condition=ready -l carto.run/workload-name=$workload,app.kubernetes.io/part-of=$workload
+kubectl wait pod --for=condition=ready -l serving.knative.dev/service=$workload,app.kubernetes.io/part-of=$workload


### PR DESCRIPTION
- carto.run labels is also present on build pods and prevent waiting from ever exiting because pods never reach 1
- required by default supply chain